### PR TITLE
[RunnerHub] switch hub to transient to fix missing client messages

### DIFF
--- a/Sproutopia/EngineWorker.cs
+++ b/Sproutopia/EngineWorker.cs
@@ -205,13 +205,16 @@ namespace Sproutopia
                         await _visualiserContext.Clients.All.SendAsync(VisualiserCommands.ReceiveInitialGameState,
                             _gameState.MapAllToDto());
 #endif
-                        foreach (var bot in _gameState.BotManager.GetAllBotStates())
-                        {
-                            await _runnerContext.Clients.Client(bot.Value.ConnectionId)
-                                .SendAsync(RunnerCommands.ReceiveBotState, _gameState.MapToBotDto(bot.Key));
 
-                            _gameLogger.Information("{@_gameState}", _gameState.MapAllToDto());
-                        }
+                        await Parallel.ForEachAsync(_gameState.BotManager.GetAllBotStates(), async (bot, cancellationToken) => {
+                            await _runnerContext.Clients.Client(bot.Value.ConnectionId).SendAsync(
+                                    RunnerCommands.ReceiveBotState,
+                                    _gameState.MapToBotDto(bot.Key),
+                                    cancellationToken
+                            );
+                        });
+
+                        _gameLogger.Information("{@_gameState}", _gameState.MapAllToDto());
 
                         #endregion
                     }

--- a/Sproutopia/Program.cs
+++ b/Sproutopia/Program.cs
@@ -61,7 +61,7 @@ namespace Sproutopia
                         services.AddSingleton<GameState>();
                         services.AddSingleton<IBotManager, BotManager>();
                         services.AddSingleton<IGardenManager, GardenManager>();
-                        services.AddSingleton<RunnerHub>();
+                        services.AddTransient<RunnerHub>();
                         services.AddSignalR(options =>
                         {
                             //Uncomment for detailed error log for SignalR


### PR DESCRIPTION
This fixes the RunnerHub to be a transient, rather than a singleton. This was causing random missing messages on the bots, which is likely related to these issues:

* https://forum.entelect.co.za/t/comms-error-with-reference-bot/1686
* https://github.com/EntelectChallenge/2024-Sproutopia/issues/5

The issue comes from the SignalR hub needing to be transient, from https://learn.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-8.0#create-and-use-hubs

<img width="680" alt="image" src="https://github.com/EntelectChallenge/2024-Sproutopia/assets/10784365/4cecac7c-dc8f-4b06-bfd5-b5c62c4db14b">

Thanks @LeroyChristopherDunn for his hint on his PR!

This also makes the sending of the botstate updates run in parallel to avoid giving player 1 an advantage over other players (by giving them more time to process the state update). PS on the current implementation, the log file is written in each iteration of the loop, which makes this difference much larger (I measured up to a 90ms difference between player 1 and 4's update), so I fixed that as well

